### PR TITLE
correct operators

### DIFF
--- a/app/protected/components/helpers.php
+++ b/app/protected/components/helpers.php
@@ -93,7 +93,7 @@ function getFolderName($folder_id) {
 
 function message_udate($tstamp) {
   // if day of year of now is less than or equal to time_str
-  if (date('z',time()) > date('z',$tstamp)) {
+  if (date('z',time()) <= date('z',$tstamp)) {
     $date_str = Yii::app()->dateFormatter->format('h:mm a',$tstamp,'medium',null);
   }
     else {


### PR DESCRIPTION
When processing dates  `message_udate($tstamp)` should show the hour and minute for the current day and month and day for messages older than the current day. The comment line reflects this, however the wrong operator was used. Alternatively, it could just be `=` rather than `<=` because the current day should never be less than message day.